### PR TITLE
fix broken tests from dice selection and ES6 issue

### DIFF
--- a/server/game/AbilityTargets/AbilityTargetOptions.js
+++ b/server/game/AbilityTargets/AbilityTargetOptions.js
@@ -76,7 +76,9 @@ class AbilityTargetOptions {
         });
     }
 
-    defaultHandler = (option) => option;
+    defaultHandler(option) {
+        return option;
+    }
 }
 
 module.exports = AbilityTargetOptions;

--- a/test/server/cards/Ashes-Core/MassiveGrowth.spec.js
+++ b/test/server/cards/Ashes-Core/MassiveGrowth.spec.js
@@ -18,7 +18,7 @@ describe('Massive Growth alteration', function () {
     it('attaches to target card, grants attack and life', function () {
         this.player1.clickCard(this.massiveGrowth);
         this.player1.clickPrompt('Play this Alteration');
-        this.player1.clickDie(2);
+        this.player1.clickDie(1);
         this.player1.clickPrompt('Done');
         this.player1.clickCard(this.mistSpirit);
         expect(this.mistSpirit.upgrades.length).toBe(1);

--- a/test/server/cards/Ashes-Core/SummonIceGolem.spec.js
+++ b/test/server/cards/Ashes-Core/SummonIceGolem.spec.js
@@ -22,7 +22,7 @@ describe('Summon Ice Golem', function () {
         it('should place an ice golem into play', function () {
             this.player1.clickCard(this.summonIceGolem);
             this.player1.clickPrompt('Summon Ice Golem');
-            this.player1.clickDie(3);
+            this.player1.clickDie(1);
             this.player1.clickPrompt('Done');
             this.player1.clickCard(this.player1.archives[0]);
 
@@ -55,7 +55,7 @@ describe('Summon Ice Golem', function () {
             expect(this.player1.inPlay[0].damage).toBe(1);
             this.player1.clickCard(this.summonIceGolem);
             this.player1.clickPrompt('Summon Ice Golem');
-            this.player1.clickDie(3);
+            this.player1.clickDie(1);
             this.player1.clickPrompt('Done');
             this.player1.clickCard(this.player1.archives[0]);
 

--- a/test/server/cost.spec.js
+++ b/test/server/cost.spec.js
@@ -1,5 +1,5 @@
 const { parseCosts, parseDiceCost } = require('../../server/game/costs.js');
-const DiceCost = require('../../server/game/costs/dicecost');
+const DiceCost = require('../../server/game/Costs/dicecost');
 const DiceCount = require('../../server/game/DiceCount');
 const { Magic, Level } = require('../../server/constants');
 


### PR DESCRIPTION
**AbilityTargetOptions.js** 
This is the error I was getting when running tests:

> /home/ashteki/git/ashteki/server/game/AbilityTargets/AbilityTargetOptions.js:79
> &nbsp;&nbsp;&nbsp;defaultHandler = (option) => option;
> &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;^
>
>SyntaxError: Unexpected token =

Looks like it's an issue with Jasmine not supporting ES6. Fixing this one spot was easier that setting up a transpiler.

**MassiveGrowth.spec.js and SummonIceGolem.spec.js**
Both of these tests were failing on selecting the additional dice to pay. Debugging showed the issue was that the dice chosen in test case were already selected. Changing from die at index 3, to dies at index 1 fixed the issue in both cases.

**cost.spec.js** 
Jasmine couldn't find the import when running the test due to a capitalization issue.

