### PR TITLE
update end of turn confirmation

### DIFF
--- a/server/game/gamesteps/main/actionwindow.js
+++ b/server/game/gamesteps/main/actionwindow.js
@@ -145,10 +145,10 @@ class ActionWindow extends UiPrompt {
 
         if (choice === 'done') {
             let cards = player.cardsInPlay.concat(player.hand);
-            if (cards.some((card) => card.getLegalActions(player).length > 0)) {
+            if (player.actions.main && cards.some((card) => card.getLegalActions(player).length > 0)) {
                 this.game.promptWithHandlerMenu(player, {
                     source: 'End Turn',
-                    activePromptTitle: 'Are you sure you want to end your turn?',
+                    activePromptTitle: 'Pass your main action?',
                     choices: ['Yes', 'No'],
                     handlers: [() => this.endActionWindow(), () => true]
                 });

--- a/server/game/gamesteps/main/actionwindow.js
+++ b/server/game/gamesteps/main/actionwindow.js
@@ -145,7 +145,10 @@ class ActionWindow extends UiPrompt {
 
         if (choice === 'done') {
             let cards = player.cardsInPlay.concat(player.hand);
-            if (player.actions.main && cards.some((card) => card.getLegalActions(player).length > 0)) {
+            if (
+                player.actions.main &&
+                cards.some((card) => card.getLegalActions(player).length > 0)
+            ) {
                 this.game.promptWithHandlerMenu(player, {
                     source: 'End Turn',
                     activePromptTitle: 'Pass your main action?',

--- a/test/helpers/playerinteractionwrapper.js
+++ b/test/helpers/playerinteractionwrapper.js
@@ -487,7 +487,7 @@ class PlayerInteractionWrapper {
         }
 
         this.clickPrompt('End Turn');
-        if (this.currentPrompt().menuTitle === 'Are you sure you want to end your turn?') {
+        if (this.currentPrompt().menuTitle === 'Pass your main action?') {
             this.clickPrompt('Yes');
         }
     }


### PR DESCRIPTION
Update end of turn confirmation to only trigger if main action has not been used. Also updated verbiage of confirmation to indicate that it is the main action being passed. Left legal actions check so that if there are no legal actions, prompt is still skipped.