### PR TITLE
Added target for deep freeze discard and test case

### DIFF
--- a/server/game/cards/Ashes-Core/DeepFreeze.js
+++ b/server/game/cards/Ashes-Core/DeepFreeze.js
@@ -18,7 +18,7 @@ class DeepFreeze extends Card {
                     gameAction: ability.actions.removeStatus({ target: this }),
                     then: {
                         condition: () => this.status === 0,
-                        gameAction: ability.actions.discard()
+                        gameAction: ability.actions.discard({ target: this })
                     }
                 })
             ]

--- a/test/server/cards/Ashes-Core/DeepFreeze.spec.js
+++ b/test/server/cards/Ashes-Core/DeepFreeze.spec.js
@@ -47,5 +47,6 @@ describe('Deep Freeze', function () {
         this.player1.clickCard(this.mistSpirit);
         this.player1.clickPrompt('Thaw');
         expect(this.deepFreeze.location).toBe('discard');
+        expect(this.mistSpirit.location).toBe('play area');
     });
 });


### PR DESCRIPTION
Issue 121

Problem was the the target of the discard ability was the unit. Followed the same pattern as the remove status token ability. Also added a test case for this.