### PR TITLE
make empower focus 1 ability optional

### DIFF
--- a/server/game/cards/Ashes-Core/BodyInversion.js
+++ b/server/game/cards/Ashes-Core/BodyInversion.js
@@ -1,0 +1,31 @@
+const { Level, Magic } = require('../../../constants.js');
+const Card = require('../../Card.js');
+const DiceCount = require('../../DiceCount.js');
+
+class BodyInversion extends Card {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Body Inversion a unit',
+            location: 'spellboard',
+            cost: [
+                ability.costs.sideAction(),
+                ability.costs.exhaust(),
+                ability.costs.dice([new DiceCount(1, Level.Class, Magic.Illusion)])
+            ],
+            target: {
+                cardType: ['Ally', 'Conjuration'],
+                gameAction: ability.actions.cardLastingEffect((context) => ({
+                    duration: 'untilEndOfTurn',
+                    effect: [
+                        ability.effects.setAttack(context.target.life),
+                        ability.effects.setLife(context.target.attack)
+                    ]
+                }))
+            }
+        });
+    }
+}
+
+BodyInversion.id = 'body-inversion';
+
+module.exports = BodyInversion;

--- a/server/game/cards/Ashes-Core/Empower.js
+++ b/server/game/cards/Ashes-Core/Empower.js
@@ -28,6 +28,7 @@ class Empower extends Card {
                 condition: (context) => context.source.focus,
                 targets: {
                     tokenBoy: {
+                        optional: true,
                         controller: 'self',
                         activePromptTitle: 'Choose a unit with status tokens',
                         cardType: BattlefieldTypes,
@@ -38,6 +39,7 @@ class Empower extends Card {
                         activePromptTitle: 'how many tokens?',
                         mode: 'options',
                         options: (context) =>
+                            context.targets.tokenBoy &&
                             this.getValueOptions(context.targets.tokenBoy.tokens.status),
                         handler: (option) => (this.chosenValue = option.value)
                     },

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -40,6 +40,7 @@ const Effects = {
     removeKeyword: (keyword) => EffectBuilder.card.static('removeKeyword', keyword),
     setPower: (amount) => EffectBuilder.card.flexible('setPower', amount),
     setAttack: (amount) => EffectBuilder.card.flexible('setAttack', amount),
+    setLife: (amount) => EffectBuilder.card.flexible('setLife', amount),
     takeControl: (player) => EffectBuilder.card.static('takeControl', player),
     entersPlayUnderOpponentsControl: () =>
         EffectBuilder.card.static('entersPlayUnderOpponentsControl'),

--- a/test/server/cards/Ashes-Core/BodyInversion.spec.js
+++ b/test/server/cards/Ashes-Core/BodyInversion.spec.js
@@ -1,0 +1,32 @@
+describe('Body Inversion', function () {
+    beforeEach(function () {
+        this.setupTest({
+            player1: {
+                phoenixborn: 'aradel-summergaard',
+                dicepool: ['illusion'],
+                spellboard: ['body-inversion']
+            },
+            player2: {
+                phoenixborn: 'maeoni-viper',
+                inPlay: ['anchornaut', 'crimson-bomber']
+            }
+        });
+    });
+
+    it('flips attack and life', function () {
+        this.player1.clickCard(this.bodyInversion);
+        this.player1.clickPrompt('Body Inversion a unit');
+        this.player1.clickCard(this.crimsonBomber);
+
+        expect(this.crimsonBomber.attack).toBe(2);
+        expect(this.crimsonBomber.life).toBe(3);
+    });
+
+    it('kills unit with 0 attack', function () {
+        this.player1.clickCard(this.bodyInversion);
+        this.player1.clickPrompt('Body Inversion a unit');
+        this.player1.clickCard(this.anchornaut);
+
+        expect(this.anchornaut.location).toBe('discard');
+    });
+});

--- a/test/server/cards/Ashes-Core/Empower-focus.spec.js
+++ b/test/server/cards/Ashes-Core/Empower-focus.spec.js
@@ -60,22 +60,22 @@ describe('Empower focussed', function () {
         expect(this.hammerKnight.damage).toBe(1);
     });
 
-    // it('token removal is optional', function () {
-    //     expect(this.ironWorker.tokens.status).toBeUndefined();
+    it('token removal is optional', function () {
+        expect(this.ironWorker.tokens.status).toBeUndefined();
 
-    //     this.player1.clickCard(this.empower);
-    //     this.player1.clickPrompt('Empower');
-    //     this.player1.clickDie(0);
-    //     expect(this.player1).toHavePrompt('Choose a unit to empower');
-    //     this.player1.clickCard(this.ironWorker);
+        this.player1.clickCard(this.empower);
+        this.player1.clickPrompt('Empower');
+        this.player1.clickDie(0);
+        expect(this.player1).toHavePrompt('Choose a unit to empower');
+        this.player1.clickCard(this.ironWorker);
 
-    //     expect(this.ironWorker.tokens.status).toBe(1);
-    //     expect(this.player1).toHavePrompt('Choose a unit with status tokens');
+        expect(this.ironWorker.tokens.status).toBe(1);
+        expect(this.player1).toHavePrompt('Choose a unit with status tokens');
 
-    //     this.player1.clickPrompt('Done');
-    //     expect(this.player1).toHaveDefaultPrompt();
+        this.player1.clickPrompt('Done');
+        expect(this.player1).toHaveDefaultPrompt();
 
-    //     expect(this.anchornaut.status).toBe(2);
-    //     expect(this.hammerKnight.damage).toBe(0);
-    // });
+        expect(this.anchornaut.status).toBe(2);
+        expect(this.hammerKnight.damage).toBe(0);
+    });
 });

--- a/test/server/cards/Ashes-Core/Empower.spec.js
+++ b/test/server/cards/Ashes-Core/Empower.spec.js
@@ -1,126 +1,31 @@
 describe('Empower', function () {
-    describe('unfocused', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    phoenixborn: 'coal-roarkwin',
-                    inPlay: ['iron-worker'],
-                    dicepool: ['natural', 'ceremonial', 'charm', 'charm'],
-                    hand: [],
-                    spellboard: ['empower']
-                },
-                player2: {
-                    phoenixborn: 'aradel-summergaard',
-                    inPlay: ['blue-jaguar', 'mist-spirit'],
-                    spellboard: ['summon-butterfly-monk']
-                }
-            });
-        });
-
-        it('adds a token to one unit', function () {
-            expect(this.ironWorker.tokens.status).toBeUndefined();
-
-            this.player1.clickCard(this.empower);
-            this.player1.clickPrompt('Empower');
-            this.player1.clickDie(0);
-            expect(this.player1).toHavePrompt('Choose a unit to empower');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.ironWorker.status).toBe(1);
-            expect(this.player1).toHavePrompt('Choose a card to play or use');
+    beforeEach(function () {
+        this.setupTest({
+            player1: {
+                phoenixborn: 'coal-roarkwin',
+                inPlay: ['iron-worker'],
+                dicepool: ['natural', 'ceremonial', 'charm', 'charm'],
+                hand: [],
+                spellboard: ['empower']
+            },
+            player2: {
+                phoenixborn: 'aradel-summergaard',
+                inPlay: ['blue-jaguar', 'mist-spirit'],
+                spellboard: ['summon-butterfly-monk']
+            }
         });
     });
 
-    describe('focus 1', function () {
-        beforeEach(function () {
-            this.setupTest({
-                player1: {
-                    phoenixborn: 'coal-roarkwin',
-                    inPlay: ['iron-worker'],
-                    dicepool: ['natural', 'ceremonial', 'charm', 'charm'],
-                    spellboard: ['empower', 'empower']
-                },
-                player2: {
-                    phoenixborn: 'aradel-summergaard',
-                    inPlay: ['iron-rhino']
-                }
-            });
-        });
+    it('adds a token to one unit', function () {
+        expect(this.ironWorker.tokens.status).toBeUndefined();
 
-        it('deals 1 damage to a unit', function () {
-            expect(this.ironWorker.tokens.status).toBeUndefined();
+        this.player1.clickCard(this.empower);
+        this.player1.clickPrompt('Empower');
+        this.player1.clickDie(0);
+        expect(this.player1).toHavePrompt('Choose a unit to empower');
+        this.player1.clickCard(this.ironWorker);
 
-            this.player1.clickCard(this.empower);
-            this.player1.clickPrompt('Empower');
-            this.player1.clickDie(0);
-            expect(this.player1).toHavePrompt('Choose a unit to empower');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.ironWorker.status).toBe(1);
-            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.player1).toHavePrompt('how many tokens?');
-            this.player1.clickPrompt('1');
-
-            expect(this.player1).toHavePrompt('Choose a unit to damage');
-            this.player1.clickCard(this.ironRhino);
-
-            expect(this.ironWorker.status).toBe(0);
-            expect(this.ironRhino.damage).toBe(1);
-        });
-
-        it('deals 2 damage to a unit', function () {
-            this.ironWorker.tokens.status = 2;
-
-            this.player1.clickCard(this.empower);
-            this.player1.clickPrompt('Empower');
-            this.player1.clickDie(0);
-            expect(this.player1).toHavePrompt('Choose a unit to empower');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.ironWorker.status).toBe(3);
-            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.player1).toHavePrompt('how many tokens?');
-            this.player1.clickPrompt('2');
-
-            expect(this.player1).toHavePrompt('Choose a unit to damage');
-            this.player1.clickCard(this.ironRhino);
-
-            expect(this.ironWorker.status).toBe(1);
-            expect(this.ironRhino.damage).toBe(2);
-        });
-
-        it('focus ability is cancelable', function () {
-            this.player1.clickCard(this.empower);
-            this.player1.clickPrompt('Empower');
-            this.player1.clickDie(0);
-            expect(this.player1).toHavePrompt('Choose a unit to empower');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.ironWorker.status).toBe(1);
-            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
-            this.player1.clickPrompt('Done');
-            expect(this.player1).toHavePrompt('Choose a card to play or use');
-        });
-
-        it('ability bails if 0 tokens removed', function () {
-            this.player1.clickCard(this.empower);
-            this.player1.clickPrompt('Empower');
-            this.player1.clickDie(0);
-            expect(this.player1).toHavePrompt('Choose a unit to empower');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.ironWorker.status).toBe(1);
-            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
-            this.player1.clickCard(this.ironWorker);
-
-            expect(this.player1).toHavePrompt('how many tokens?');
-            this.player1.clickPrompt('0');
-
-            expect(this.player1).toHavePrompt('Choose a card to play or use');
-        });
+        expect(this.ironWorker.status).toBe(1);
+        expect(this.player1).toHavePrompt('Choose a card to play or use');
     });
 });

--- a/test/server/cards/Ashes-Core/Empower.spec.js
+++ b/test/server/cards/Ashes-Core/Empower.spec.js
@@ -1,31 +1,126 @@
 describe('Empower', function () {
-    beforeEach(function () {
-        this.setupTest({
-            player1: {
-                phoenixborn: 'coal-roarkwin',
-                inPlay: ['iron-worker'],
-                dicepool: ['natural', 'ceremonial', 'charm', 'charm'],
-                hand: [],
-                spellboard: ['empower']
-            },
-            player2: {
-                phoenixborn: 'aradel-summergaard',
-                inPlay: ['blue-jaguar', 'mist-spirit'],
-                spellboard: ['summon-butterfly-monk']
-            }
+    describe('unfocused', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    phoenixborn: 'coal-roarkwin',
+                    inPlay: ['iron-worker'],
+                    dicepool: ['natural', 'ceremonial', 'charm', 'charm'],
+                    hand: [],
+                    spellboard: ['empower']
+                },
+                player2: {
+                    phoenixborn: 'aradel-summergaard',
+                    inPlay: ['blue-jaguar', 'mist-spirit'],
+                    spellboard: ['summon-butterfly-monk']
+                }
+            });
+        });
+
+        it('adds a token to one unit', function () {
+            expect(this.ironWorker.tokens.status).toBeUndefined();
+
+            this.player1.clickCard(this.empower);
+            this.player1.clickPrompt('Empower');
+            this.player1.clickDie(0);
+            expect(this.player1).toHavePrompt('Choose a unit to empower');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.ironWorker.status).toBe(1);
+            expect(this.player1).toHavePrompt('Choose a card to play or use');
         });
     });
 
-    it('adds a token to one unit', function () {
-        expect(this.ironWorker.tokens.status).toBeUndefined();
+    describe('focus 1', function () {
+        beforeEach(function () {
+            this.setupTest({
+                player1: {
+                    phoenixborn: 'coal-roarkwin',
+                    inPlay: ['iron-worker'],
+                    dicepool: ['natural', 'ceremonial', 'charm', 'charm'],
+                    spellboard: ['empower', 'empower']
+                },
+                player2: {
+                    phoenixborn: 'aradel-summergaard',
+                    inPlay: ['iron-rhino']
+                }
+            });
+        });
 
-        this.player1.clickCard(this.empower);
-        this.player1.clickPrompt('Empower');
-        this.player1.clickDie(0);
-        expect(this.player1).toHavePrompt('Choose a unit to empower');
-        this.player1.clickCard(this.ironWorker);
+        it('deals 1 damage to a unit', function () {
+            expect(this.ironWorker.tokens.status).toBeUndefined();
 
-        expect(this.ironWorker.tokens.status).toBe(1);
-        expect(this.player1).toHavePrompt('Choose a card to play or use');
+            this.player1.clickCard(this.empower);
+            this.player1.clickPrompt('Empower');
+            this.player1.clickDie(0);
+            expect(this.player1).toHavePrompt('Choose a unit to empower');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.ironWorker.status).toBe(1);
+            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.player1).toHavePrompt('how many tokens?');
+            this.player1.clickPrompt('1');
+
+            expect(this.player1).toHavePrompt('Choose a unit to damage');
+            this.player1.clickCard(this.ironRhino);
+
+            expect(this.ironWorker.status).toBe(0);
+            expect(this.ironRhino.damage).toBe(1);
+        });
+
+        it('deals 2 damage to a unit', function () {
+            this.ironWorker.tokens.status = 2;
+
+            this.player1.clickCard(this.empower);
+            this.player1.clickPrompt('Empower');
+            this.player1.clickDie(0);
+            expect(this.player1).toHavePrompt('Choose a unit to empower');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.ironWorker.status).toBe(3);
+            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.player1).toHavePrompt('how many tokens?');
+            this.player1.clickPrompt('2');
+
+            expect(this.player1).toHavePrompt('Choose a unit to damage');
+            this.player1.clickCard(this.ironRhino);
+
+            expect(this.ironWorker.status).toBe(1);
+            expect(this.ironRhino.damage).toBe(2);
+        });
+
+        it('focus ability is cancelable', function () {
+            this.player1.clickCard(this.empower);
+            this.player1.clickPrompt('Empower');
+            this.player1.clickDie(0);
+            expect(this.player1).toHavePrompt('Choose a unit to empower');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.ironWorker.status).toBe(1);
+            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
+            this.player1.clickPrompt('Done');
+            expect(this.player1).toHavePrompt('Choose a card to play or use');
+        });
+
+        it('ability bails if 0 tokens removed', function () {
+            this.player1.clickCard(this.empower);
+            this.player1.clickPrompt('Empower');
+            this.player1.clickDie(0);
+            expect(this.player1).toHavePrompt('Choose a unit to empower');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.ironWorker.status).toBe(1);
+            expect(this.player1).toHavePrompt('Choose a unit with status tokens');
+            this.player1.clickCard(this.ironWorker);
+
+            expect(this.player1).toHavePrompt('how many tokens?');
+            this.player1.clickPrompt('0');
+
+            expect(this.player1).toHavePrompt('Choose a card to play or use');
+        });
     });
 });


### PR DESCRIPTION
Issue 91:

Instead of making the whole `then` optional, I made the `tokenBoy` portion optional. This also then required a check in the `amount` section to verify that `tokenBoy` isn't undefined. I added unit tests to cover the different focus 1 scenarios. 