### PR TITLE
make empoer focus ability optional

### DIFF
--- a/server/game/cards/Ashes-Core/Empower.js
+++ b/server/game/cards/Ashes-Core/Empower.js
@@ -28,6 +28,7 @@ class Empower extends Card {
                 condition: (context) => context.source.focus,
                 targets: {
                     tokenBoy: {
+                        optional: true,
                         controller: 'self',
                         activePromptTitle: 'Choose a unit with status tokens',
                         cardType: BattlefieldTypes,
@@ -38,6 +39,7 @@ class Empower extends Card {
                         activePromptTitle: 'how many tokens?',
                         mode: 'options',
                         options: (context) =>
+                            context.targets.tokenBoy &&
                             this.getValueOptions(context.targets.tokenBoy.tokens.status),
                         handler: (option) => (this.chosenValue = option.value)
                     },

--- a/test/server/cards/Ashes-Core/Empower-focus.spec.js
+++ b/test/server/cards/Ashes-Core/Empower-focus.spec.js
@@ -60,22 +60,22 @@ describe('Empower focussed', function () {
         expect(this.hammerKnight.damage).toBe(1);
     });
 
-    // it('token removal is optional', function () {
-    //     expect(this.ironWorker.tokens.status).toBeUndefined();
+    it('token removal is optional', function () {
+        expect(this.ironWorker.tokens.status).toBeUndefined();
 
-    //     this.player1.clickCard(this.empower);
-    //     this.player1.clickPrompt('Empower');
-    //     this.player1.clickDie(0);
-    //     expect(this.player1).toHavePrompt('Choose a unit to empower');
-    //     this.player1.clickCard(this.ironWorker);
+        this.player1.clickCard(this.empower);
+        this.player1.clickPrompt('Empower');
+        this.player1.clickDie(0);
+        expect(this.player1).toHavePrompt('Choose a unit to empower');
+        this.player1.clickCard(this.ironWorker);
 
-    //     expect(this.ironWorker.tokens.status).toBe(1);
-    //     expect(this.player1).toHavePrompt('Choose a unit with status tokens');
+        expect(this.ironWorker.tokens.status).toBe(1);
+        expect(this.player1).toHavePrompt('Choose a unit with status tokens');
 
-    //     this.player1.clickPrompt('Done');
-    //     expect(this.player1).toHaveDefaultPrompt();
+        this.player1.clickPrompt('Done');
+        expect(this.player1).toHaveDefaultPrompt();
 
-    //     expect(this.anchornaut.status).toBe(2);
-    //     expect(this.hammerKnight.damage).toBe(0);
-    // });
+        expect(this.anchornaut.status).toBe(2);
+        expect(this.hammerKnight.damage).toBe(0);
+    });
 });


### PR DESCRIPTION
Issue 91:

Instead of making the whole then optional, I made the tokenBoy portion optional. This also then required a check in the amount section to verify that tokenBoy isn't undefined. Uncommented the test you already had.