### PR TITLE
Implement body inversion

### DIFF
--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -537,11 +537,10 @@ class Card extends PlayableObject {
         }
 
         const copyEffect = this.mostRecentEffect('copyCard');
-        const printedAttack = this.anyEffect('setPrintedAttack')
-            ? this.mostRecentEffect('setPrintedAttack')
-            : copyEffect
+        const printedAttackEffect = this.mostRecentEffect('setPrintedAttack');
+        const printedAttack = copyEffect
             ? copyEffect.printedAttack
-            : this.printedAttack;
+            : printedAttackEffect || this.printedAttack;
         return Math.max(0, printedAttack + this.sumEffects('modifyAttack'));
     }
 
@@ -587,11 +586,10 @@ class Card extends PlayableObject {
         }
 
         const copyEffect = this.mostRecentEffect('copyCard');
-        const printedLife = this.anyEffect('setPrintedLife')
-            ? this.mostRecentEffect('setPrintedLife')
-            : copyEffect
+        const printedLifeEffect = this.mostRecentEffect('setPrintedLife');
+        const printedLife = copyEffect
             ? copyEffect.printedLife
-            : this.printedLife;
+            : printedLifeEffect || this.printedLife;
         return printedLife + this.sumEffects('modifyLife');
     }
 

--- a/server/game/Card.js
+++ b/server/game/Card.js
@@ -537,7 +537,11 @@ class Card extends PlayableObject {
         }
 
         const copyEffect = this.mostRecentEffect('copyCard');
-        const printedAttack = copyEffect ? copyEffect.printedAttack : this.printedAttack;
+        const printedAttack = this.anyEffect('setPrintedAttack')
+            ? this.mostRecentEffect('setPrintedAttack')
+            : copyEffect
+            ? copyEffect.printedAttack
+            : this.printedAttack;
         return Math.max(0, printedAttack + this.sumEffects('modifyAttack'));
     }
 
@@ -583,7 +587,11 @@ class Card extends PlayableObject {
         }
 
         const copyEffect = this.mostRecentEffect('copyCard');
-        const printedLife = copyEffect ? copyEffect.printedLife : this.printedLife;
+        const printedLife = this.anyEffect('setPrintedLife')
+            ? this.mostRecentEffect('setPrintedLife')
+            : copyEffect
+            ? copyEffect.printedLife
+            : this.printedLife;
         return printedLife + this.sumEffects('modifyLife');
     }
 

--- a/server/game/cards/Ashes-Core/BodyInversion.js
+++ b/server/game/cards/Ashes-Core/BodyInversion.js
@@ -17,8 +17,21 @@ class BodyInversion extends Card {
                 gameAction: ability.actions.cardLastingEffect((context) => ({
                     duration: 'untilEndOfTurn',
                     effect: [
-                        ability.effects.setAttack(context.target.life),
-                        ability.effects.setLife(context.target.attack)
+                        ability.effects.setAttack(() => {
+                            const printedLife = context.target.anyEffect('setPrintedLife')
+                                ? context.target.mostRecentEffect('setPrintedLife')
+                                : context.target.printedLife;
+                            return Math.max(
+                                0,
+                                printedLife + context.target.sumEffects('modifyAttack')
+                            );
+                        }),
+                        ability.effects.setLife(() => {
+                            const printedAttack = context.target.anyEffect('setPrintedAttack')
+                                ? context.target.mostRecentEffect('setPrintedAttack')
+                                : context.target.printedAttack;
+                            return printedAttack + context.target.sumEffects('modifyLife');
+                        })
                     ]
                 }))
             }

--- a/server/game/cards/Ashes-Core/BodyInversion.js
+++ b/server/game/cards/Ashes-Core/BodyInversion.js
@@ -18,18 +18,18 @@ class BodyInversion extends Card {
                     duration: 'untilEndOfTurn',
                     effect: [
                         ability.effects.setAttack(() => {
-                            const printedLife = context.target.anyEffect('setPrintedLife')
-                                ? context.target.mostRecentEffect('setPrintedLife')
-                                : context.target.printedLife;
+                            const printedLife =
+                                context.target.mostRecentEffect('setPrintedLife') ||
+                                context.target.printedLife;
                             return Math.max(
                                 0,
                                 printedLife + context.target.sumEffects('modifyAttack')
                             );
                         }),
                         ability.effects.setLife(() => {
-                            const printedAttack = context.target.anyEffect('setPrintedAttack')
-                                ? context.target.mostRecentEffect('setPrintedAttack')
-                                : context.target.printedAttack;
+                            const printedAttack =
+                                context.target.mostRecentEffect('setPrintedAttack') ||
+                                context.target.printedAttack;
                             return printedAttack + context.target.sumEffects('modifyLife');
                         })
                     ]

--- a/server/game/cards/Ashes-Core/BodyInversion.js
+++ b/server/game/cards/Ashes-Core/BodyInversion.js
@@ -1,0 +1,31 @@
+const { Level, Magic } = require('../../../constants.js');
+const Card = require('../../Card.js');
+const DiceCount = require('../../DiceCount.js');
+
+class BodyInversion extends Card {
+    setupCardAbilities(ability) {
+        this.action({
+            title: 'Body Inversion a unit',
+            location: 'spellboard',
+            cost: [
+                ability.costs.sideAction(),
+                ability.costs.exhaust(),
+                ability.costs.dice([new DiceCount(1, Level.Class, Magic.Illusion)])
+            ],
+            target: {
+                cardType: ['Ally', 'Conjuration'],
+                gameAction: ability.actions.cardLastingEffect((context) => ({
+                    duration: 'untilEndOfTurn',
+                    effect: [
+                        ability.effects.setAttack(context.target.life),
+                        ability.effects.setLife(context.target.attack)
+                    ]
+                }))
+            }
+        });
+    }
+}
+
+BodyInversion.id = 'body-inversion';
+
+module.exports = BodyInversion;

--- a/server/game/cards/Ashes-Core/SilverSnake.js
+++ b/server/game/cards/Ashes-Core/SilverSnake.js
@@ -4,7 +4,7 @@ const Card = require('../../Card.js');
 class SilverSnake extends Card {
     setupCardAbilities(ability) {
         this.persistentEffect({
-            effect: [ability.effects.setAttack(() => this.status)]
+            effect: [ability.effects.setPrintedAttack(() => this.status)]
         });
 
         this.forcedReaction({

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -40,7 +40,9 @@ const Effects = {
     removeKeyword: (keyword) => EffectBuilder.card.static('removeKeyword', keyword),
     setPower: (amount) => EffectBuilder.card.flexible('setPower', amount),
     setAttack: (amount) => EffectBuilder.card.flexible('setAttack', amount),
+    setPrintedAttack: (amount) => EffectBuilder.card.flexible('setPrintedAttack', amount),
     setLife: (amount) => EffectBuilder.card.flexible('setLife', amount),
+    setPrintedLife: (amount) => EffectBuilder.card.flexible('setPrintedLife', amount),
     takeControl: (player) => EffectBuilder.card.static('takeControl', player),
     entersPlayUnderOpponentsControl: () =>
         EffectBuilder.card.static('entersPlayUnderOpponentsControl'),

--- a/server/game/effects.js
+++ b/server/game/effects.js
@@ -40,6 +40,7 @@ const Effects = {
     removeKeyword: (keyword) => EffectBuilder.card.static('removeKeyword', keyword),
     setPower: (amount) => EffectBuilder.card.flexible('setPower', amount),
     setAttack: (amount) => EffectBuilder.card.flexible('setAttack', amount),
+    setLife: (amount) => EffectBuilder.card.flexible('setLife', amount),
     takeControl: (player) => EffectBuilder.card.static('takeControl', player),
     entersPlayUnderOpponentsControl: () =>
         EffectBuilder.card.static('entersPlayUnderOpponentsControl'),

--- a/test/server/cards/Ashes-Core/BodyInversion.spec.js
+++ b/test/server/cards/Ashes-Core/BodyInversion.spec.js
@@ -11,8 +11,9 @@ describe('Body Inversion', function () {
             player2: {
                 phoenixborn: 'maeoni-viper',
                 inPlay: ['anchornaut', 'frost-fang', 'silver-snake'],
-                dicepool: ['illusion'],
-                spellboard: ['body-inversion']
+                dicepool: ['illusion', 'natural', 'natural'],
+                spellboard: ['body-inversion'],
+                hand: ['crystal-shield']
             }
         });
     });
@@ -54,6 +55,27 @@ describe('Body Inversion', function () {
         expect(this.anchornaut.life).toBe(2);
     });
 
+    it('flips only printed attack and life with buff applied after', function () {
+        // now body invert it. the buff from the shield should stay on the life
+        this.player1.clickCard(this.bodyInversion);
+        this.player1.clickPrompt('Body Inversion a unit');
+        this.player1.clickCard(this.frostFang);
+
+        expect(this.frostFang.attack).toBe(1);
+        expect(this.frostFang.life).toBe(3);
+
+        // Put a Crystal Shield on the unit to give a persistent buff
+        this.player1.clickCard(this.crystalShield);
+        this.player1.clickPrompt('Play This Alteration');
+        this.player1.clickDie(2);
+        this.player1.clickPrompt('Done');
+        this.player1.clickCard(this.frostFang);
+
+        expect(this.frostFang.location).toBe('play area');
+        expect(this.frostFang.attack).toBe(1);
+        expect(this.frostFang.life).toBe(5);
+    });
+
     it('interation with silver snake', function () {
         this.player1.clickCard(this.crimsonBomber);
         this.player1.clickPrompt('Detonate 3');
@@ -80,14 +102,6 @@ describe('Body Inversion', function () {
     });
 
     it('interation with silver snake and crystal shield', function () {
-        this.player1.clickCard(this.crystalShield);
-        this.player1.clickPrompt('Play This Alteration');
-        this.player1.clickDie(2);
-        this.player1.clickPrompt('Done');
-        this.player1.clickCard(this.silverSnake);
-
-        expect(this.silverSnake.life).toBe(6);
-
         this.player1.clickCard(this.crimsonBomber);
         this.player1.clickPrompt('Detonate 3');
         this.player1.clickPrompt('Done');
@@ -102,6 +116,15 @@ describe('Body Inversion', function () {
         this.player2.clickCard(this.silverSnake);
 
         expect(this.silverSnake.location).toBe('play area');
+        expect(this.silverSnake.attack).toBe(4);
+        expect(this.silverSnake.life).toBe(1);
+
+        this.player2.clickCard('crystal-shield', 'any', 'self');
+        this.player2.clickPrompt('Play This Alteration');
+        this.player2.clickDie(2);
+        this.player2.clickPrompt('Done');
+        this.player2.clickCard(this.silverSnake);
+
         expect(this.silverSnake.attack).toBe(4);
         expect(this.silverSnake.life).toBe(3);
 

--- a/test/server/cards/Ashes-Core/BodyInversion.spec.js
+++ b/test/server/cards/Ashes-Core/BodyInversion.spec.js
@@ -1,0 +1,32 @@
+describe('Body Inversion', function () {
+    beforeEach(function () {
+        this.setupTest({
+            player1: {
+                phoenixborn: 'aradel-summergaard',
+                dicepool: ['illusion'],
+                spellboard: ['body-inversion']
+            },
+            player2: {
+                phoenixborn: 'maeoni-viper',
+                inPlay: ['anchornaut', 'crimson-bomber']
+            }
+        });
+    });
+
+    it('flips attack and life', function () {
+        this.player1.clickCard(this.bodyInversion);
+        this.player1.clickPrompt('Body Inversion a unit');
+        this.player1.clickCard(this.crimsonBomber);
+
+        expect(this.crimsonBomber.attack).toBe(2);
+        expect(this.crimsonBomber.life).toBe(3);
+    });
+
+    it('kills unit with 0 attack', function () {
+        this.player1.clickCard(this.bodyInversion);
+        this.player1.clickPrompt('Body Inversion a unit');
+        this.player1.clickCard(this.anchornaut);
+
+        expect(this.anchornaut.location).toBe('discard');
+    });
+});

--- a/test/server/cards/Ashes-Core/BodyInversion.spec.js
+++ b/test/server/cards/Ashes-Core/BodyInversion.spec.js
@@ -3,12 +3,16 @@ describe('Body Inversion', function () {
         this.setupTest({
             player1: {
                 phoenixborn: 'aradel-summergaard',
-                dicepool: ['illusion'],
-                spellboard: ['body-inversion']
+                dicepool: ['illusion', 'natural', 'natural'],
+                spellboard: ['body-inversion'],
+                hand: ['crystal-shield'],
+                inPlay: ['crimson-bomber']
             },
             player2: {
                 phoenixborn: 'maeoni-viper',
-                inPlay: ['anchornaut', 'crimson-bomber']
+                inPlay: ['anchornaut', 'frost-fang', 'silver-snake'],
+                dicepool: ['illusion'],
+                spellboard: ['body-inversion']
             }
         });
     });
@@ -16,10 +20,10 @@ describe('Body Inversion', function () {
     it('flips attack and life', function () {
         this.player1.clickCard(this.bodyInversion);
         this.player1.clickPrompt('Body Inversion a unit');
-        this.player1.clickCard(this.crimsonBomber);
+        this.player1.clickCard(this.frostFang);
 
-        expect(this.crimsonBomber.attack).toBe(2);
-        expect(this.crimsonBomber.life).toBe(3);
+        expect(this.frostFang.attack).toBe(1);
+        expect(this.frostFang.life).toBe(3);
     });
 
     it('kills unit with 0 attack', function () {
@@ -28,5 +32,83 @@ describe('Body Inversion', function () {
         this.player1.clickCard(this.anchornaut);
 
         expect(this.anchornaut.location).toBe('discard');
+    });
+
+    it('flips only printed attack and life', function () {
+        // Put a Crystal Shield on the unit to give a persistent buff
+        this.player1.clickCard(this.crystalShield);
+        this.player1.clickPrompt('Play This Alteration');
+        this.player1.clickDie(2);
+        this.player1.clickPrompt('Done');
+        this.player1.clickCard(this.anchornaut);
+        expect(this.anchornaut.attack).toBe(0);
+        expect(this.anchornaut.life).toBe(3);
+
+        // now body invert it. the buff from the shield should stay on the life
+        this.player1.clickCard(this.bodyInversion);
+        this.player1.clickPrompt('Body Inversion a unit');
+        this.player1.clickCard(this.anchornaut);
+
+        expect(this.anchornaut.location).toBe('play area');
+        expect(this.anchornaut.attack).toBe(1);
+        expect(this.anchornaut.life).toBe(2);
+    });
+
+    it('interation with silver snake', function () {
+        this.player1.clickCard(this.crimsonBomber);
+        this.player1.clickPrompt('Detonate 3');
+        this.player1.clickPrompt('Done');
+
+        expect(this.silverSnake.attack).toBe(1);
+        expect(this.silverSnake.status).toBe(1);
+
+        this.player1.endTurn();
+
+        this.player2.clickCard('body-inversion', 'any', 'self');
+        this.player2.clickPrompt('Body Inversion a unit');
+        this.player2.clickCard(this.silverSnake);
+
+        expect(this.silverSnake.location).toBe('play area');
+        expect(this.silverSnake.attack).toBe(4);
+        expect(this.silverSnake.life).toBe(1);
+
+        this.player2.endTurn();
+
+        expect(this.silverSnake.location).toBe('play area');
+        expect(this.silverSnake.attack).toBe(1);
+        expect(this.silverSnake.life).toBe(4);
+    });
+
+    it('interation with silver snake and crystal shield', function () {
+        this.player1.clickCard(this.crystalShield);
+        this.player1.clickPrompt('Play This Alteration');
+        this.player1.clickDie(2);
+        this.player1.clickPrompt('Done');
+        this.player1.clickCard(this.silverSnake);
+
+        expect(this.silverSnake.life).toBe(6);
+
+        this.player1.clickCard(this.crimsonBomber);
+        this.player1.clickPrompt('Detonate 3');
+        this.player1.clickPrompt('Done');
+
+        expect(this.silverSnake.attack).toBe(1);
+        expect(this.silverSnake.status).toBe(1);
+
+        this.player1.endTurn();
+
+        this.player2.clickCard('body-inversion', 'any', 'self');
+        this.player2.clickPrompt('Body Inversion a unit');
+        this.player2.clickCard(this.silverSnake);
+
+        expect(this.silverSnake.location).toBe('play area');
+        expect(this.silverSnake.attack).toBe(4);
+        expect(this.silverSnake.life).toBe(3);
+
+        this.player2.endTurn();
+
+        expect(this.silverSnake.location).toBe('play area');
+        expect(this.silverSnake.attack).toBe(1);
+        expect(this.silverSnake.life).toBe(6);
     });
 });


### PR DESCRIPTION
**Body Inversion**

Hard part on this one was Silver Snake since it's printed value is technically equal to X instead of being like Dreaded Wraith where it's an attack buff. To handle this, I had to add new effects (`setPrintedAttack` and `setPrintedLife`). This allows the adjustment of the printed values without having to actually change the values. The only use case for this with Body Inversion so far seems to be the snake but hopefully it's extensible.

Only thing I'm slightly uncertain about is whether to give precedence to a copy effect or a printed value effect. I decided to go with the copy effect since it seems more likely that will be layered after setting printed values. If this causes issues then it might be worth adding a method to determine which of the two is more recent, but that could be a narrower enough of an edge case that we may not need to worry about it.