### PR TITLE
first pass at a AbilityTargetPlayer

### DIFF
--- a/server/game/AbilityTargets/AbilityTargetOptions.js
+++ b/server/game/AbilityTargets/AbilityTargetOptions.js
@@ -72,7 +72,7 @@ class AbilityTargetOptions {
             waitingPromptTitle: 'Waiting for opponent',
             source: this.properties.source || context.source,
             options: this.getOptions(context),
-            optionsHandler: (option) => (context.option = this.handler(option))
+            optionsHandler: (option) => (context.option = this.handler(option, context))
         });
     }
 

--- a/server/game/AbilityTargets/AbilityTargetPlayer.js
+++ b/server/game/AbilityTargets/AbilityTargetPlayer.js
@@ -4,8 +4,8 @@ class AbilityTargetPlayer extends AbilityTargetOptions {
     constructor(name, properties, ability) {
         super(name, properties, ability);
         this.options = [
-            { name: 'Me', value: false },
-            { name: 'Opponent', value: true }
+            { name: 'Opponent', value: true },
+            { name: 'Me', value: false }
         ];
         this.handler = (option, context) =>
             (context.target = option.value ? context.player.opponent : context.player);

--- a/server/game/AbilityTargets/AbilityTargetPlayer.js
+++ b/server/game/AbilityTargets/AbilityTargetPlayer.js
@@ -1,0 +1,21 @@
+const AbilityTargetOptions = require('./AbilityTargetOptions');
+
+class AbilityTargetPlayer extends AbilityTargetOptions {
+    constructor(name, properties, ability) {
+        super(name, properties, ability);
+        this.options = [
+            { name: 'Me', value: false },
+            { name: 'Opponent', value: true }
+        ];
+        this.handler = (option, context) =>
+            (context.target = option.value ? context.player.opponent : context.player);
+    }
+
+    getGameAction(context) {
+        return this.properties.gameAction.filter((gameAction) =>
+            gameAction.hasLegalTarget(context)
+        );
+    }
+}
+
+module.exports = AbilityTargetPlayer;

--- a/server/game/GameActions/ChosenDiscardAction.js
+++ b/server/game/GameActions/ChosenDiscardAction.js
@@ -3,6 +3,11 @@ const PlayerAction = require('./PlayerAction');
 class ChosenDiscardAction extends PlayerAction {
     setDefaultProperties() {
         this.amount = 1;
+        this.targetPlayer = null;
+    }
+
+    defaultTargets(context) {
+        return [context.player.opponent, context.player];
     }
 
     setup() {
@@ -13,6 +18,9 @@ class ChosenDiscardAction extends PlayerAction {
     }
 
     canAffect(player, context) {
+        if (context && context.target && player !== context.target) {
+            return false;
+        }
         if (player.hand.length === 0 || this.amount === 0) {
             return false;
         }

--- a/server/game/GameActions/ChosenDiscardAction.js
+++ b/server/game/GameActions/ChosenDiscardAction.js
@@ -3,7 +3,6 @@ const PlayerAction = require('./PlayerAction');
 class ChosenDiscardAction extends PlayerAction {
     setDefaultProperties() {
         this.amount = 1;
-        this.targetPlayer = null;
     }
 
     defaultTargets(context) {

--- a/server/game/baseability.js
+++ b/server/game/baseability.js
@@ -5,6 +5,7 @@ const AbilityTargetTrait = require('./AbilityTargets/AbilityTargetTrait');
 const AbilityTargetOptions = require('./AbilityTargets/AbilityTargetOptions');
 const AbilityTargetCardName = require('./AbilityTargets/AbilityTargetCardName');
 const AbilityTargetDie = require('./AbilityTargets/AbilityTargetDie');
+const AbilityTargetPlayer = require('./AbilityTargets/AbilityTargetPlayer');
 
 /**
  * Base class representing an ability that can be done by the player. This
@@ -87,6 +88,8 @@ class BaseAbility {
             return new AbilityTargetCardName(name, properties, this);
         } else if (properties.mode === 'options') {
             return new AbilityTargetOptions(name, properties, this);
+        } else if (properties.mode === 'player') {
+            return new AbilityTargetPlayer(name, properties, this);
         }
 
         return new AbilityTargetCard(name, properties, this);

--- a/server/game/cards/Ashes-Core/ThreeEyedOwl.js
+++ b/server/game/cards/Ashes-Core/ThreeEyedOwl.js
@@ -5,7 +5,11 @@ class ThreeEyedOwl extends Card {
         this.action({
             title: 'Memory Drain 1',
             cost: [ability.costs.mainAction(), ability.costs.exhaust()],
-            gameAction: ability.actions.chosenDiscard({ player: this.controller.opponent })
+            target: {
+                mode: 'player',
+                activePromptTitle: 'Which player discards?',
+                gameAction: ability.actions.chosenDiscard()
+            }
         });
     }
 }

--- a/test/server/cards/Ashes-Core/ThreeEyedOwl.spec.js
+++ b/test/server/cards/Ashes-Core/ThreeEyedOwl.spec.js
@@ -1,0 +1,40 @@
+describe('Three eyed Owl', function () {
+    beforeEach(function () {
+        this.setupTest({
+            player1: {
+                phoenixborn: 'coal-roarkwin',
+                inPlay: ['three-eyed-owl'],
+                dicepool: ['charm', 'charm'],
+                hand: ['summon-masked-wolf'],
+                spellboard: ['purge']
+            },
+            player2: {
+                phoenixborn: 'aradel-summergaard',
+                inPlay: ['blue-jaguar', 'mist-spirit'],
+                hand: ['summon-butterfly-monk', 'enchanted-violinist']
+            }
+        });
+    });
+
+    it('discards opponents card', function () {
+        this.player1.clickCard(this.threeEyedOwl);
+        this.player1.clickPrompt('Memory Drain 1');
+        this.player1.clickPrompt('Opponent');
+
+        this.player2.clickCard(this.summonButterflyMonk);
+
+        expect(this.summonButterflyMonk.location).toBe('discard');
+        expect(this.enchantedViolinist.location).toBe('hand');
+    });
+
+    it('discards my card', function () {
+        this.player1.clickCard(this.threeEyedOwl);
+        this.player1.clickPrompt('Memory Drain 1');
+        this.player1.clickPrompt('Me');
+
+        this.player1.clickCard(this.summonMaskedWolf);
+
+        expect(this.summonMaskedWolf.location).toBe('discard');
+        expect(this.player1.hand.length).toBe(0);
+    });
+});


### PR DESCRIPTION
I put this into a PR just to make it easier to see the changes. Definitely needs more testing before merging.

I coded up an example for Three Eyed Owl. It should be extensible to the top deck discards by using a similar pattern.

I'm not sure if the AbilityTargetOptions.js is the right one to extend since it prompts with a drop down where buttons would probably be easier. But then again, opponent is the one auto selected, so it's only two clicks if targeting yourself, which seems unlikely with most of the abilities.

The ones that put summons into the opponent's battlefield will probably require some extra thought as well.