### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,6 @@ RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 COPY package.json /usr/src/app
 COPY package-lock.json /usr/src/app
-RUN npm install --no-optional
+RUN npm install
 COPY . /usr/src/app
 EXPOSE 49153


### PR DESCRIPTION
Remove --no-optional from npm install as this was causing JSDOM issues for setup on Mac