### PR TITLE
Emberoot lizard bug fix

### DIFF
--- a/server/game/cards/Time/EmberootLizard.js
+++ b/server/game/cards/Time/EmberootLizard.js
@@ -23,13 +23,15 @@ class EmberootLizard extends Card {
                     optional: true,
                     cardCondition: (card, context) => card !== context.source,
                     activePromptTitle: 'Ignite',
+                    waitingPromptTitle: 'Ignite: waiting for opponent',
                     cardType: BattlefieldTypes,
                     gameAction: ability.actions.dealDamage({
-                        amount: 1
+                        amount: 1,
+                        showMessage: true
                     })
                 }
             },
-            effect: 'increase its attack value by 1'
+            effect: 'increase its attack value by 1 and may deal damage'
         });
     }
 }


### PR DESCRIPTION
Partial fix for BUG #609. I expanded on the Ignite ability message and noticed that ShowMessage = False by default in dealDamageAction, so I set ShowMessage = True for the Lizard so that if a unit is damaged there is a message that this occurred.

Ideally, there would be two messages, the first saying that the Emberoot Lizard had its attack value increased, and second that it was used to deal 1 damage to the target.