### PR TITLE
Bug fix #634

### DIFF
--- a/server/game/cards/Mixed-Expansions/AngelicRescue.js
+++ b/server/game/cards/Mixed-Expansions/AngelicRescue.js
@@ -7,7 +7,8 @@ class AngelicRescue extends Card {
             when: {
                 onDamageDealt: (event, context) =>
                     event.context.player === context.player.opponent && // opponent action
-                    BattlefieldTypes.includes(event.card.type) && // its a unit
+                    BattlefieldTypes.includes(event.card.type) && // it's a unit
+                    event.card.controller === context.player && // it's one of my units
                     !event.fightEvent // not a fight
             },
             gameAction: ability.actions.preventDamage((context) => ({

--- a/server/game/cards/Time/FateReflection.js
+++ b/server/game/cards/Time/FateReflection.js
@@ -7,7 +7,8 @@ class FateReflection extends Card {
             when: {
                 onDamageDealt: (event, context) =>
                     event.context.player === context.player.opponent && // opponent action
-                    BattlefieldTypes.includes(event.card.type) && // its a unit
+                    BattlefieldTypes.includes(event.card.type) && // it's a unit
+                    event.card.controller === context.player && // it's one of my units
                     !event.fightEvent // not a fight
             },
             gameAction: ability.actions.preventDamage((context) => ({

--- a/test/server/cards/AngelicRescue.spec.js
+++ b/test/server/cards/AngelicRescue.spec.js
@@ -1,0 +1,56 @@
+describe('Angelic Rescue reaction spell', function () {
+    beforeEach(function () {
+        this.setupTest({
+            player1: {
+                phoenixborn: 'aradel-summergaard',
+                inPlay: ['flute-mage', 'hammer-knight'],
+                spellboard: [],
+                hand: ['anchornaut'],
+                dicepool: ['natural', 'natural', 'charm', 'charm']
+            },
+            player2: {
+                phoenixborn: 'coal-roarkwin',
+                inPlay: ['iron-worker', 'mist-spirit'],
+                spellboard: ['summon-butterfly-monk'],
+                dicepool: ['natural', 'natural', 'charm', 'charm', 'divine'],
+                archives: ['butterfly-monk'],
+                hand: ['angelic-rescue']
+            }
+        });
+
+        this.ironWorker.tokens.damage = 1;
+    });
+
+    it('can be played when a unit takes damage', function () {
+        this.player1.clickCard(this.anchornaut);
+        this.player1.clickPrompt('Play This Ally');
+        this.player1.clickDie(2);
+        this.player1.clickCard(this.ironWorker); // target
+
+        // any interrupts?
+        expect(this.player2).toHavePrompt(
+            'Any Reactions to Iron Worker receiving 1 damage from Anchornaut?'
+        );
+        this.player2.clickCard(this.angelicRescue); // click angelic rescue to play as reaction
+        this.player2.clickDie(4);
+
+        expect(this.angelicRescue.location).toBe('discard');
+        expect(this.player2.hand.length).toBe(0);
+
+        expect(this.hammerKnight.damage).toBe(0);
+        expect(this.ironWorker.damage).toBe(0); // healed iron worker
+    });
+
+    it('cannot be played when an opposing unit takes damage', function () {
+        this.player1.clickCard(this.anchornaut);
+        this.player1.clickPrompt('Play This Ally');
+        this.player1.clickDie(2);
+        this.player1.clickCard(this.hammerKnight); // target
+
+        // expect no interrupts
+        expect(this.player2).not.toHavePrompt(
+            'Any Reactions to Hammer Knight receiving 1 damage from Anchornaut?'
+        );
+        expect(this.player2).not.toBeAbleToSelect(this.angelicRescue);
+    });
+});

--- a/test/server/cards/FateReflection.spec.js
+++ b/test/server/cards/FateReflection.spec.js
@@ -28,6 +28,9 @@ describe('Fate Reflection reaction spell', function () {
         this.player1.clickCard(this.ironWorker); // target
 
         // any interrupts?
+        expect(this.player2).toHavePrompt(
+            'Any Reactions to Iron Worker receiving 1 damage from Anchornaut?'
+        );
         this.player2.clickCard(this.fateReflection); // click fate reflection to play as reaction
         this.player2.clickDie(4);
         this.player2.clickCard(this.hammerKnight); // deal damage to hammerKnight
@@ -47,6 +50,9 @@ describe('Fate Reflection reaction spell', function () {
         this.player1.clickCard(this.ironWorker);
 
         // any interrupts?
+        expect(this.player2).toHavePrompt(
+            'Any Reactions to Iron Worker receiving 2 damage from Aradel Summergaard?'
+        );
         this.player2.clickCard(this.fateReflection); // click fate reflection to play as reaction
         this.player2.clickDie(4);
         this.player2.clickCard(this.hammerKnight); // deal damage to hammerKnight
@@ -56,5 +62,20 @@ describe('Fate Reflection reaction spell', function () {
 
         expect(this.hammerKnight.damage).toBe(2); // apply correct damage
         expect(this.ironWorker.damage).toBe(0);
+    });
+
+    it('cannot be played when an opposing unit takes damage', function () {
+        expect(this.ironWorker.damage).toBe(0);
+
+        this.player1.clickCard(this.anchornaut);
+        this.player1.clickPrompt('Play This Ally');
+        this.player1.clickDie(2);
+        this.player1.clickCard(this.hammerKnight); // target
+
+        // expect no interrupts
+        expect(this.player2).not.toHavePrompt(
+            'Any Reactions to Hammer Knight receiving 1 damage from Anchornaut?'
+        );
+        expect(this.player2).not.toBeAbleToSelect(this.fateReflection);
     });
 });

--- a/test/server/cards/Redirect.spec.js
+++ b/test/server/cards/Redirect.spec.js
@@ -40,7 +40,7 @@ describe('Redirect reaction spell', function () {
         expect(this.mistSpirit.tokens.damage).toBeUndefined;
     });
 
-    it('can be played when a phoenixborn takes Water Blast damage', function () {
+    it('can be played when a phoenixborn takes One Hundred Blades damage', function () {
         expect(this.hammerKnight.tokens.damage).toBeUndefined;
 
         this.player1.play(this.oneHundredBlades);


### PR DESCRIPTION
Angelic Rescue and Fate Reflection now confirm that the triggered damage target is controlled by the player holding the reaction spell. Fate Reflection tests updated to add this check.