### PR TITLE
Pain Shaman message fix

### DIFF
--- a/server/game/GameActions/RemoveTokenAction.js
+++ b/server/game/GameActions/RemoveTokenAction.js
@@ -48,8 +48,11 @@ class RemoveTokenAction extends CardGameAction {
                 card.removeToken(event.type, event.amount);
                 if (this.showMessage) {
                     context.game.addMessage(
-                        `{0} removes {1} {2} tokens from {3}`,
+                        event.amount == 1
+                            ? `{0} uses {1} to remove {2} {3} token from {4}`
+                            : `{0} uses {1} to remove {2} {3} tokens from {4}`,
                         context.player,
+                        context.source,
                         this.all ? 'all' : event.amount,
                         event.type,
                         event.card

--- a/server/game/cards/Mixed-Expansions/PainShaman.js
+++ b/server/game/cards/Mixed-Expansions/PainShaman.js
@@ -3,7 +3,7 @@ const Card = require('../../Card.js');
 class PainShaman extends Card {
     setupCardAbilities(ability) {
         this.entersPlay({
-            effect: 'deal 1 damage to a target unit',
+            effect: 'deal 1 damage to {0}',
             target: {
                 optional: true,
                 activePromptTitle: 'Choose a unit to damage',
@@ -13,13 +13,13 @@ class PainShaman extends Card {
                 })
             },
             then: {
-                effect: 'remove 1 damage from a unit or phoenixborn',
                 target: {
                     activePromptTitle: 'Choose a unit or Phoenixborn to heal',
                     cardType: ['Ally', 'Conjuration', 'Phoenixborn'],
                     optional: true,
                     gameAction: ability.actions.removeDamage({
-                        amount: 1
+                        amount: 1,
+                        showMessage: true
                     })
                 }
             }


### PR DESCRIPTION
Pain Shaman now creates the following event messages when played:
test2 plays Pain Shaman
test2 uses Pain Shaman to deal 1 damage to Shining Hydra
test2 uses Pain Shaman to remove 1 damage token from Shining Hydra