### PR TITLE
Meditating 0 does not use side action

### DIFF
--- a/server/game/gamesteps/MeditatePrompt.js
+++ b/server/game/gamesteps/MeditatePrompt.js
@@ -196,9 +196,10 @@ class MeditatePrompt extends UiPrompt {
             );
             // this.choosingPlayer.discardSelectedCards();
             this.game.addMessage(
-                '{0} meditates {1} to gain a {2}',
+                '{0} meditates {1} from their {2} to gain a {3}',
                 this.choosingPlayer,
                 cards,
+                cards[0].location,
                 dice
             );
             if (!this.firstTopOfDeck && this.isTopDeck) {

--- a/server/game/gamesteps/MeditatePrompt.js
+++ b/server/game/gamesteps/MeditatePrompt.js
@@ -216,7 +216,13 @@ class MeditatePrompt extends UiPrompt {
         }
 
         if (arg === 'done') {
-            this.game.addMessage('{0} meditated {1} cards/dice', player, this.count);
+            if (this.count > 0) {
+                this.game.addMessage('{0} meditated {1} cards/dice', player, this.count);
+            }
+            // If they didn't meditate at all, recover the side action
+            if (this.count == 0) {
+                this.context.player.actions.side += 1;
+            }
 
             player.sortDice();
 


### PR DESCRIPTION
This change means that a player selecting meditate, but then not carrying out any meditation will recover their side action, which I've noticed is a common issue that players use Manual Mode to work around.